### PR TITLE
Add return statement values to Expression objects

### DIFF
--- a/cython/exprtk.pxd
+++ b/cython/exprtk.pxd
@@ -41,11 +41,33 @@ cdef extern from "exprtk.hpp" namespace "exprtk":
     ivararg_function[T]* get_vararg_function(string& vararg_function_name)
     variable_ptr get_variable(string& variable_name)
 
+  cdef cppclass type_store[T]:
+    type_store() except +
+    int size
+    int type
+    cppclass scalar_view:
+      scalar_view(type_store[T]& ts) except +
+      T& v_
+    cppclass type_view[ViewType]:
+      type_view(type_store[T]& ts) except +
+      int size()
+      ViewType& operator[](int& i)
+      ViewType* data_
+    ctypedef type_view[T] vector_view
+    ctypedef type_view[char] string_view
+
+  cdef string to_str(type_store[double].string_view& view)
+
+  cdef cppclass results_context[T]:
+    results_context() except +
+    int count()
+    type_store[T] operator[](int& index)
 
   cdef cppclass expression[T]:
     expression() except +
     void register_symbol_table(symbol_table[T])
     T value()
+    results_context[T] results()
 
   cdef cppclass parser[T]:
     parser() except +
@@ -62,3 +84,5 @@ cdef extern from "exprtk.hpp" namespace "exprtk":
 ctypedef symbol_table[double] symbol_table_type
 ctypedef expression[double] expression_type
 ctypedef parser[double] parser_type
+ctypedef results_context[double] results_context_type
+ctypedef type_store[double] type_store_type

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ PACKAGE_DIR = os.path.join(CURR_DIR, 'cython', 'cexprtk')
 
 VERSION="0.3.4"
 
-PYTHON_MAJOR_VERSION = sys.version_info[0]
+# PYTHON_MAJOR_VERSION = sys.version_info[0]
+PYTHON_MAJOR_VERSION = 2
 
 COMPILER_OPTIONS = dict(
     # bigobj is needed because the PE/COFF binary format

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from setuptools import setup
 from setuptools.extension import Extension
@@ -7,6 +8,8 @@ CURR_DIR = os.path.abspath(os.path.dirname(__file__))
 PACKAGE_DIR = os.path.join(CURR_DIR, 'cython', 'cexprtk')
 
 VERSION="0.3.4"
+
+PYTHON_MAJOR_VERSION = sys.version_info[0]
 
 COMPILER_OPTIONS = dict(
     # bigobj is needed because the PE/COFF binary format
@@ -82,7 +85,7 @@ def extensions():
   exts = [cexprtkExtension(ext), custom_function_callbacksExtension(ext), symbol_tableExtension(ext)]
 
   if USE_CYTHON:
-    return cythonize(exts,include_path = ['cython', 'cython/cexprtk'])
+    return cythonize(exts,include_path = ['cython', 'cython/cexprtk'], compiler_directives={'language_level' : PYTHON_MAJOR_VERSION})
   return exts
 
 

--- a/tests/test_cexprtk.py
+++ b/tests/test_cexprtk.py
@@ -46,6 +46,39 @@ class ExpressionTestCase(unittest.TestCase):
     v = expression()
     self.assertAlmostEqual(18.0, v)
 
+  def testReturnResults(self):
+    """Test that basic return calls in expressions work."""
+    st = cexprtk.Symbol_Table({}, {})
+    exp = "var x[2] := {1, 2}; return [4, 'abc', x];"
+    expression = cexprtk.Expression(exp, st)
+    v = expression.value()
+
+    results_list = expression.results()
+
+    self.assertEqual(3, len(results_list))
+
+    scalar_val = results_list[0]
+    self.assertAlmostEqual(4.0, scalar_val)
+
+    string_val = results_list[1]
+    self.assertEqual('abc', string_val)
+
+    vector_val = results_list[2]
+    self.assertEqual(2, len(vector_val))
+    self.assertAlmostEqual(1.0, vector_val[0])
+    self.assertAlmostEqual(2.0, vector_val[1])
+
+  def testResultsEmptyWithNoReturn(self):
+    """Test that an expression has no results
+    when it doesn't include a return statement"""
+    st = cexprtk.Symbol_Table({},{})
+    expression = cexprtk.Expression("2+2", st)
+    v = expression.value()
+    self.assertAlmostEqual(4.0, v)
+
+    results_list = expression.results()
+    self.assertEqual(0, len(results_list))
+
 
 class Symbol_TableVariablesTestCase(unittest.TestCase):
   """Tests for cexprtk._Symbol_Table_Variables"""


### PR DESCRIPTION
This PR wraps the results() method from ExprTk Expressions so that we can access the results from a return statement in cexprtk.

It provides a new method on the cexprtk.Expression class, `results`, which returns a Python list containing floating point values (scalars), string values (strings), or lists of floating point values (vectors).

I've also included a pair of unit tests to verify functionality for when a return statement is used and when it isn't.